### PR TITLE
Alters where the locking of the object occurs.

### DIFF
--- a/includes/apply.inc
+++ b/includes/apply.inc
@@ -43,6 +43,7 @@ function islandora_xquery_apply_results($batch_id) {
  *   The batch context.
  */
 function islandora_xquery_apply_query_batch_operation($batch_id, array &$context) {
+  global $user;
   module_load_include('inc', 'islandora_object_lock', 'includes/utilities');
 
   if (!isset($context['sandbox']['progress'])) {
@@ -93,8 +94,9 @@ function islandora_xquery_apply_query_batch_operation($batch_id, array &$context
     $include = TRUE;
     $fedora_object = islandora_object_load($result->pid);
     $locked = islandora_object_lock_is_locked($fedora_object);
+    $lock_owner = islandora_object_lock_get_lock_username($fedora_object);
     $created_date = strtotime($fedora_object[$result->dsid]->createdDate);
-    if ($locked) {
+    if ($locked && $lock_owner != $user->name) {
       $ignored_objects[] = $result->pid;
       $include = FALSE;
     }
@@ -102,7 +104,6 @@ function islandora_xquery_apply_query_batch_operation($batch_id, array &$context
       $ignored_objects[] = $result->pid;
       $include = FALSE;
     }
-    islandora_object_lock_set_object_lock($result->pid);
     islandora_xquery_apply_query_batch_apply_diff($result, $context);
   }
 

--- a/includes/solr_results.inc
+++ b/includes/solr_results.inc
@@ -293,6 +293,10 @@ function islandora_xquery_run_query_batch_operation(array $dsids, $object_range,
   // Run the find/replace on all applicable datastreams.
   $current_object = islandora_xquery_run_query_batch_operation_get_object($context);
 
+  // Lock the object
+  module_load_include('inc', 'islandora_object_lock', 'includes/utilities');
+  islandora_object_lock_set_object_lock($current_object->id);
+
   foreach ($current_object as $datastream) {
     if (array_intersect($dsids, array($datastream->id))) {
       islandora_xquery_run_query_batch_operation_generate_diff($current_object, $datastream, $xquery, $context);


### PR DESCRIPTION
Moves object locking to occur during diff generation, ensuring users
cannot edit an object while find and replace is being reviewed.

Unlocks still occur as usual.
