### PR TITLE
Fix Zorba version comparison.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -44,7 +44,7 @@ function islandora_xquery_admin_form($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Zorba'),
     '#description' => t('Zorba is used to execute XQuery queries.<br/>!msg', array(
-      '!msg' => islandora_executable_available_message($zorba, $version, ISLANDORA_XQUERY_ZORBA_REQUIRED_VERSION))
+      '!msg' => islandora_executable_available_message($zorba, $version, ISLANDORA_XQUERY_ZORBA_MINIMUM_VERSION))
     ),
     '#default_value' => $zorba,
     '#ajax' => array(

--- a/islandora_xquery.install
+++ b/islandora_xquery.install
@@ -188,15 +188,16 @@ function islandora_xquery_requirements($phase) {
       if ($zorba_version === FALSE) {
         $requirements['zorba'] = array(
           'title' => $t('Zorba'),
-          'value' => $t('Zorba could not be found. Islandora XQuery requires Zorba %version.', array('%version' => ISLANDORA_XQUERY_ZORBA_REQUIRED_VERSION)),
+          'value' => $t('Zorba could not be found. Islandora XQuery requires Zorba %version.', array('%version' => ISLANDORA_XQUERY_ZORBA_MINIMUM_VERSION)),
           'severity' => REQUIREMENT_ERROR,
         );
       }
-      elseif (version_compare($zorba_version, ISLANDORA_XQUERY_ZORBA_REQUIRED_VERSION, '!=')) {
+      elseif (version_compare($zorba_version, ISLANDORA_XQUERY_ZORBA_MINIMUM_VERSION, '<=')
+        && version_compare($zorba_version, ISLANDORA_XQUERY_ZORBA_MAXIMUM_VERSION, '>')) {
         $requirements['zorba'] = array(
           'title' => $t('Zorba'),
           'value' => $t('Islandora XQuery requires Zorba %required_version. Version %version is currently installed.', array(
-            '%required_version' => ISLANDORA_XQUERY_ZORBA_REQUIRED_VERSION,
+            '%required_version' => ISLANDORA_XQUERY_ZORBA_MINIMUM_VERSION,
             '%version' => $zorba_version,
             )
           ),

--- a/islandora_xquery.module
+++ b/islandora_xquery.module
@@ -7,7 +7,8 @@
  *   Handle "the i18n_string integration fun".
  */
 
-define('ISLANDORA_XQUERY_ZORBA_REQUIRED_VERSION', '3.0.0');
+define('ISLANDORA_XQUERY_ZORBA_MINIMUM_VERSION', '3');
+define('ISLANDORA_XQUERY_ZORBA_MAXIMUM_VERSION', '4');
 define('ISLANDORA_XQUERY_ZORBA_DEFAULT_LOCATION', '/usr/bin/zorba');
 
 define('ISLANDORA_XQUERY_STATUS_PENDING', 'PENDING');

--- a/tests/xquery.test
+++ b/tests/xquery.test
@@ -37,7 +37,8 @@ class XQueryUnitTestCase extends DrupalUnitTestCase {
    */
   public function testXQueryExistence() {
     $version = islandora_xquery_get_zorba_version();
-    if ($version === FALSE || version_compare(ISLANDORA_XQUERY_ZORBA_REQUIRED_VERSION, $version, '!=')) {
+    if ($version === FALSE || version_compare(ISLANDORA_XQUERY_ZORBA_MINIMUM_VERSION, $version, '<=')
+      && version_compare($zorba_version, ISLANDORA_XQUERY_ZORBA_MAXIMUM_VERSION, '>')) {
       $this->fail('Valid version of Zorba was not found.');
       return;
     }


### PR DESCRIPTION
Zorba appears to follow the [Semantic Versioning
Standards](http://semver.org/), which means we should be able to use
version 3.0.0, 3.1.0, 3.99.99, etc. without worrying about something
breaking. But our functions to compare versions were only checking exact
version number matches, which is not ideal.